### PR TITLE
Don't use noreturn as a macro name

### DIFF
--- a/config.h
+++ b/config.h
@@ -87,14 +87,14 @@ typedef float git_float;
 #if defined(__GNUC__)
 // GCC and compatible compilers such as clang
 #  define maybe_unused  __attribute__((__unused__))
-#  define noreturn      __attribute__((__noreturn__))
+#  define git_noreturn  __attribute__((__noreturn__))
 #elif defined(_MSC_VER)
 // Microsoft Visual Studio
 #  define maybe_unused
-#  define noreturn      __declspec(noreturn)
+#  define git_noreturn  __declspec(noreturn)
 #else
 #  define maybe_unused
-#  define noreturn
+#  define git_noreturn
 #endif
 
 #endif // GIT_CONFIG_H

--- a/git.h
+++ b/git.h
@@ -35,7 +35,7 @@ extern void git (const git_uint8 * game,
                  git_uint32 cacheSize,
                  git_uint32 undoSize);
 
-extern noreturn void fatalError (const char *);
+extern git_noreturn void fatalError (const char *);
 
 // memory.c
 

--- a/memory.h
+++ b/memory.h
@@ -102,8 +102,8 @@ extern void shutdownMemory ();
 // Utility functions -- these just pass an appropriate
 // string to fatalError().
 
-extern noreturn void memReadError (git_uint32 address);
-extern noreturn void memWriteError (git_uint32 address);
+extern git_noreturn void memReadError (git_uint32 address);
+extern git_noreturn void memWriteError (git_uint32 address);
 
 // Functions for reading and writing game memory.
 


### PR DESCRIPTION
"noreturn" is a reserved word in C11, so should not be #define'd;
instead, use a namespaced version for the macro defined in git.h.